### PR TITLE
Document Update 

### DIFF
--- a/api/2.6/org/eclipse/persistence/sessions/DatabaseLogin.html
+++ b/api/2.6/org/eclipse/persistence/sessions/DatabaseLogin.html
@@ -2058,7 +2058,7 @@ extends <a href="../../../../org/eclipse/persistence/sessions/DatasourceLogin.ht
  a query after a query has failed because of a communication issue.
  EclipseLink will only attempt to reconnect when EclipseLink can determine that a communication failure occurred
  on a read query executed outside of a transaction.  By default EclipseLink will attempt to retry the
- query 3 times, by setting this value to 0 EclipseLink will not retry queries.</div>
+ query 3 times, by setting this value to -1 EclipseLink will not retry queries.</div>
 </li>
 </ul>
 <a name="getServerName--">

--- a/api/2.6/org/eclipse/persistence/sessions/DatabaseLogin.html
+++ b/api/2.6/org/eclipse/persistence/sessions/DatabaseLogin.html
@@ -2584,8 +2584,7 @@ extends <a href="../../../../org/eclipse/persistence/sessions/DatasourceLogin.ht
 <ul class="blockList">
 <li class="blockList">
 <h4>setQueryRetryAttemptCount</h4>
-<pre>public&nbsp;void&nbsp;
-  (int&nbsp;queryRetryAttemptCount)</pre>
+<pre>public&nbsp;void&nbsp;setQueryRetryAttemptCount(int&nbsp;queryRetryAttemptCount)</pre>
 <div class="block">PUBLIC:
  Set the number of attempts EclipseLink should make to re-connect to a database and re-execute 
  a query after a query has failed because of a communication issue.

--- a/api/2.6/org/eclipse/persistence/sessions/DatabaseLogin.html
+++ b/api/2.6/org/eclipse/persistence/sessions/DatabaseLogin.html
@@ -2058,7 +2058,7 @@ extends <a href="../../../../org/eclipse/persistence/sessions/DatasourceLogin.ht
  a query after a query has failed because of a communication issue.
  EclipseLink will only attempt to reconnect when EclipseLink can determine that a communication failure occurred
  on a read query executed outside of a transaction.  By default EclipseLink will attempt to retry the
- query 3 times, by setting this value to -1 EclipseLink will not retry queries.</div>
+ query 3 times, by setting this value to 0 EclipseLink will not retry queries.</div>
 </li>
 </ul>
 <a name="getServerName--">
@@ -2584,13 +2584,14 @@ extends <a href="../../../../org/eclipse/persistence/sessions/DatasourceLogin.ht
 <ul class="blockList">
 <li class="blockList">
 <h4>setQueryRetryAttemptCount</h4>
-<pre>public&nbsp;void&nbsp;setQueryRetryAttemptCount(int&nbsp;queryRetryAttemptCount)</pre>
+<pre>public&nbsp;void&nbsp;
+  (int&nbsp;queryRetryAttemptCount)</pre>
 <div class="block">PUBLIC:
  Set the number of attempts EclipseLink should make to re-connect to a database and re-execute 
  a query after a query has failed because of a communication issue.
  EclipseLink will only attempt to reconnect when EclipseLink can determine that a communication failure occurred
  on a read query executed outside of a transaction.  By default EclipseLink will attempt to retry the
- query 3 times, by setting this value to 0 EclipseLink will not retry queries.</div>
+ query 3 times, by setting this value to -1 EclipseLink will not retry queries.</div>
 </li>
 </ul>
 <a name="setDefaultNullValue-java.lang.Class-java.lang.Object-">


### PR DESCRIPTION
Fix inconsistency between documentation and implementation for queryRetryAttemptCount=0 setting.



According to the [DatabaseLogin JavaDoc](https://javadoc.io/doc/org.eclipse.persistence/eclipselink/2.6.9/org/eclipse/persistence/sessions/DatabaseLogin.html#setQueryRetryAttemptCount-int-):

"by setting this value to 0 EclipseLink will not retry queries"

However, the actual implementation allows one retry attempt when queryRetryAttemptCount=0, contradicting the documentation.According to the [DatabaseLogin JavaDoc](https://javadoc.io/doc/org.eclipse.persistence/eclipselink/2.6.9/org/eclipse/persistence/sessions/DatabaseLogin.html#setQueryRetryAttemptCount-int-):

So changing the value from 0 to -1 to disable queryRetryAttemptCount.